### PR TITLE
Add support to mssql and pdo_dblib

### DIFF
--- a/files/brews/freetds.rb
+++ b/files/brews/freetds.rb
@@ -1,0 +1,28 @@
+require 'formula'
+
+class Freetds < Formula
+  homepage 'http://www.freetds.org/'
+  url 'http://mirrors.ibiblio.org/freetds/stable/freetds-0.91.tar.gz'
+  sha1 '3ab06c8e208e82197dc25d09ae353d9f3be7db52'
+
+  depends_on "pkg-config" => :build
+  depends_on "unixodbc" => :optional
+
+  def install
+    args = %W[--prefix=#{prefix}
+              --with-openssl=/usr/bin
+              --with-tdsver=8.0
+              --mandir=#{man}
+              --enable-msdblib
+            ]
+
+    if build.include? "with-unixodbc"
+      args << "--with-unixodbc=#{Formula.factory('unixodbc').prefix}"
+    end
+
+    system "./configure", *args
+    system 'make'
+    ENV.j1 # Or fails to install on multi-core machines
+    system 'make install'
+  end
+end

--- a/manifests/dependencies/freetds.pp
+++ b/manifests/dependencies/freetds.pp
@@ -1,0 +1,16 @@
+# Installs freetds 9.1
+#
+# Usage:
+#
+#     include freedtds
+class php::dependencies::freetds {
+
+  homebrew::formula { 'freetds':
+  	source => "puppet:///modules/php/brews/freetds.rb",
+    before => Package['freetds'],
+  }
+
+  package { 'freetds':
+    ensure => '0.91',
+  }
+}

--- a/manifests/extension/mssql.pp
+++ b/manifests/extension/mssql.pp
@@ -9,6 +9,7 @@
 define php::extension::mssql(
   $php,
 ) {
+  require php::dependencies::freetds
   require php::config
 
   # Require php version eg. php::5_4_10
@@ -33,6 +34,7 @@ define php::extension::mssql(
     php_version      => $php,
 
     configure_params => $configure_params,
+    require          => Package['freetds'],
   }
 
   # Add config file once extension is installed

--- a/manifests/extension/pdo_dblib.pp
+++ b/manifests/extension/pdo_dblib.pp
@@ -9,6 +9,7 @@
 define php::extension::pdo_dblib(
   $php,
 ) {
+  require php::dependencies::freetds
   require php::config
 
   # Require php version eg. php::5_4_10
@@ -33,6 +34,7 @@ define php::extension::pdo_dblib(
     php_version      => $php,
 
     configure_params => $configure_params,
+    require          => Package['freetds'],
   }
 
   # Add config file once extension is installed


### PR DESCRIPTION
# Uncompleted pull request
## The problem

Both extensions depends on freetds is installed.

I'm planning to add a line to ensure that on both extension definitions at https://github.com/blackjid/puppet-php/blob/master/manifests/extension/mssql.pp#L35

``` puppet
php_extension { $name:
    provider         => php_source,

    extension        => $extension,

    homebrew_path    => $boxen::config::homebrewdir,
    phpenv_root      => $php::config::root,
    php_version      => $php,

    configure_params => $configure_params,
    require          => Package['freetds'],
  }
```

For that I need to run first something like this

``` puppet
package { 'freetds':
    ensure => '0.91',
  }
```

but as both extension need it I will get a Duplicate declaration error. 

For that I was thinking to add a new class like this.

``` puppet
class freetds {
  package { 'freetds':
    ensure => '0.91',
  }
}
```

and include it in both extensions

``` puppet
include freetds
```
## The question

Where can I put this class? In a `freetds.pp` file? in what folder?
