### PR TITLE
Increase xdebug max_nesting_level

### DIFF
--- a/templates/extensions/xdebug.ini.erb
+++ b/templates/extensions/xdebug.ini.erb
@@ -3,3 +3,4 @@ zend_extension=<%= module_path %>
 xdebug.file_link_format="txmt://open?url=file://%f&line=%1"
 xdebug.remote_enable = On
 xdebug.remote_autostart = 1
+xdebug.max_nesting_level = 300


### PR DESCRIPTION
When trying to run TYPO3 with the default xdebug config, max_nesting_level is not high enough to handle some of the internal reflection caching mechanisms in TYPO3.  This commit increases it from the default '100' to '300.'  

Thanks!
