### PR TITLE
Improvements to XDebug config

### DIFF
--- a/templates/extensions/xdebug.ini.erb
+++ b/templates/extensions/xdebug.ini.erb
@@ -1,6 +1,6 @@
-zend_extension=<%= @module_path %>
+zend_extension=<%= module_path %>
 
 xdebug.file_link_format="txmt://open?url=file://%f&line=%1"
 xdebug.remote_enable = On
-xdebug.remote_autostart = 1
+xdebug.remote_autostart = 0
 xdebug.max_nesting_level = 300

--- a/templates/nginx/nginx.conf.erb
+++ b/templates/nginx/nginx.conf.erb
@@ -21,6 +21,9 @@ server {
     keepalive_timeout 0;
     fastcgi_pass unix:<%= scope.lookupvar "boxen::config::socketdir" %>/<%= @name %>;
     fastcgi_param SCRIPT_FILENAME <%= @repo_dir %>/www/index.php;
+    fastcgi_read_timeout 3600s;
+    client_body_timeout 3600s;
+    send_timeout 3600s;
     fastcgi_param PATH_INFO $fastcgi_script_name;
   }
 }

--- a/templates/php-fpm-pool.conf.erb
+++ b/templates/php-fpm-pool.conf.erb
@@ -159,7 +159,7 @@ ping.path = /ping
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_terminate_timeout = 60s
+request_terminate_timeout = 0
 
 ; The timeout for serving a single request after which a PHP backtrace will be
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.

--- a/templates/php.ini.erb
+++ b/templates/php.ini.erb
@@ -437,7 +437,7 @@ expose_php = On
 ; Maximum execution time of each script, in seconds
 ; http://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
-max_execution_time = 30
+max_execution_time = 3600
 
 ; Maximum amount of time each script may spend parsing request data. It's a good
 ; idea to limit this time on productions servers in order to eliminate unexpectedly
@@ -447,7 +447,7 @@ max_execution_time = 30
 ; Development Value: 60 (60 seconds)
 ; Production Value: 60 (60 seconds)
 ; http://php.net/max-input-time
-max_input_time = 60
+max_input_time = 3600
 
 ; Maximum input variable nesting level
 ; http://php.net/max-input-nesting-level
@@ -455,7 +455,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+memory_limit = 256M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -877,7 +877,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 50M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20
@@ -905,7 +905,7 @@ allow_url_include = Off
 
 ; Default timeout for socket based streams (seconds)
 ; http://php.net/default-socket-timeout
-default_socket_timeout = 60
+default_socket_timeout = 3600
 
 ; If your scripts have to deal with files from Macintosh systems,
 ; or you are running on a Mac and need to deal with files from


### PR DESCRIPTION
In working with XDebug, I found that Nginx and/or PHP would kill the connection after 60s, making it difficult to track down those pesky bugs or get a good overview of what was happening in my applications.  This commit does the following, to make things a little easier in that regard:
- Enable Xdebug sessions up to one hour on a single request
- Increase memory limits a little bit - also sneaks in a max_upload_file_size increase (these are DEV machines after all)
- Don't auto-start XDebug (we don't necessarily want every request to run through our IDE)
