### PR TITLE
Installing new PHP project destroys pool config for other PHP projects

### DIFF
--- a/files/empty-conf-dir/README.md
+++ b/files/empty-conf-dir/README.md
@@ -1,3 +1,3 @@
-This directory is managed by the Boxen PHP module. Other files within this folder with be purged when boxen runs to ensure that the configs are clean and no files remain lying around - you have been warned!
+This directory is managed by the Boxen PHP module. Other files within this folder may be purged when boxen runs to ensure that the configs are clean and no files remain lying around - you have been warned!
 
 http://christian.hofstaedtler.name/blog/2008/11/puppet-managing-directories-recursively.html

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -40,11 +40,9 @@ define php::fpm(
     }
 
     # Set up FPM Pool config directory
-    # Purge non managed files within this, to ensure we have no conflicts
     file { $fpm_pool_config_dir:
       ensure  => directory,
       recurse => true,
-      purge   => true,
       force   => true,
       source  => 'puppet:///modules/php/empty-conf-dir',
       require => File[$version_config_root],


### PR DESCRIPTION
I have two PHP-based projects in my boxen.  It seems that when I run `boxen project1`, the other PHP project stops working (nginx doesn't work) because the pool config (`/opt/boxen/config/php/[version]/pool.d/project2-[version].conf` is removed.  I'm using `php::project` like so for all projects:

``` puppet
php::project { $name:
    source        => $source,
    php           => $php,
    elasticsearch => false,
    mysql         => "${name}_dev",
    nginx         => 'projects/shared/nginx-php.conf.erb',
    redis         => false,
}
```

I feel like I'm missing something obvious.  Is this expected behavior?  Thanks in advance to anyone who feels like helping out.
