### PR TITLE
Remove undefined variable/method 'version'

### DIFF
--- a/lib/puppet/provider/php_extension/php_source.rb
+++ b/lib/puppet/provider/php_extension/php_source.rb
@@ -46,7 +46,7 @@ protected
     # Check if tag exists in current repo, if not fetch & recheck
     if !version_present_in_cache?
       update_repository
-      raise "Version #{@resource[:php_version]} not found in PHP source" if !version_present_in_cache? version
+      raise "Version #{@resource[:php_version]} not found in PHP source" if !version_present_in_cache?
     end
   end
 


### PR DESCRIPTION
When building php extensions from source, one step is to verify the php version exists in the cache. An undefined variable/method 'version' is passed to the function 'version_present_in_cache?'. This looks like a copy/paste mistake, as this is the method signature for the php_version/php_source type.
