### PR TITLE
pecl_http should not require zookeeper.

### DIFF
--- a/manifests/extension/pecl_http.pp
+++ b/manifests/extension/pecl_http.pp
@@ -12,7 +12,6 @@ define php::extension::pecl_http(
   $version = '1.7.5'
 ) {
   include boxen::config
-  require zookeeper
 
   require php::config
   # Require php version eg. php::5_4_10


### PR DESCRIPTION
This looks like it was left over from a copy and paste job of the zookeeper extension. Annoyingly causes a requirement of zookeeper, which causes a java app to continually launch needlessly.
