### PR TITLE
Bundle freetype 2.4.11 to fix GD conflict

### DIFF
--- a/files/brews/freetype.rb
+++ b/files/brews/freetype.rb
@@ -1,6 +1,6 @@
 require 'formula'
 
-class Freetype < Formula
+class Freetypephp < Formula
   homepage 'http://www.freetype.org'
   url 'http://downloads.sf.net/project/freetype/freetype2/2.4.11/freetype-2.4.11.tar.gz'
   sha1 'a8373512281f74a53713904050e0d71c026bf5cf'

--- a/lib/puppet/provider/php_version/php_source.rb
+++ b/lib/puppet/provider/php_version/php_source.rb
@@ -229,7 +229,7 @@ Puppet::Type.type(:php_version).provide(:php_source) do
       "--with-xsl=/usr",
       "--with-gd",
       "--enable-gd-native-ttf",
-      "--with-freetype-dir=#{@resource[:homebrew_path]}/opt/freetype",
+      "--with-freetype-dir=#{@resource[:homebrew_path]}/opt/freetypephp",
       "--with-jpeg-dir=#{@resource[:homebrew_path]}/opt/jpeg",
       "--with-png-dir=#{@resource[:homebrew_path]}/opt/libpng",
       "--with-gettext=#{@resource[:homebrew_path]}/opt/gettext",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,12 +74,12 @@ class php {
   # Install freetype version 2.4.11 due to conflict with GD
   # See https://github.com/boxen/puppet-php/issues/25
 
-  homebrew::formula { 'freetype':
+  homebrew::formula { 'freetypephp':
     source => 'puppet:///modules/php/brews/freetype.rb',
-    before => Package['boxen/brews/freetype'],
+    before => Package['boxen/brews/freetypephp'],
   }
 
-  package { 'boxen/brews/freetype':
+  package { 'boxen/brews/freetypephp':
     ensure => '2.4.11',
   }
 

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -106,7 +106,7 @@ define php::version(
       require       => [
         Repository["${php::config::root}/php-src"],
         Package['gettext'],
-        Package['boxen/brews/freetype'],
+        Package['boxen/brews/freetypephp'],
         Package['gmp'],
         Package['icu4c'],
         Package['jpeg'],

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -57,7 +57,6 @@ describe "php" do
     should contain_file("/test/boxen/env.d/phpenv.sh").with_source("puppet:///modules/php/phpenv.sh")
 
     [
-      "freetype",
       "gmp",
       "icu4c",
       "jpeg",
@@ -72,6 +71,15 @@ describe "php" do
     })
 
     should contain_package("boxen/brews/autoconf213").with_ensure("2.13-boxen1")
+
+    should contain_homebrew__formula("freetypephp").with({
+      :source => "puppet:///modules/php/brews/freetype.rb",
+      :before => "Package[boxen/brews/freetypephp]"
+    })
+
+    should contain_package("boxen/brews/freetypephp").with({
+      :ensure => "2.4.11"
+    })
 
     should contain_homebrew__formula("zlibphp").with({
       :source => "puppet:///modules/php/brews/zlib.rb",

--- a/spec/defines/php_version_spec.rb
+++ b/spec/defines/php_version_spec.rb
@@ -51,7 +51,7 @@ describe "php::version" do
         :require       => [
           "Repository[/test/boxen/phpenv/php-src]",
           "Package[gettext]",
-          "Package[freetype]",
+          "Package[boxen/brews/freetypephp]",
           "Package[gmp]",
           "Package[icu4c]",
           "Package[jpeg]",


### PR DESCRIPTION
Bundle freetype 2.4.11 in with puppet-php similarly to zlib. This is to fix the conflict with GD, as mentioned in boxen/puppet-php#25. I've included version 2.4.11, as that was the version linked in #25, though version 2.5.0.1 was also mentioned as a potential candidate for bundling in [mattheath/puppet-php#46](https://github.com/mattheath/puppet-php/issues/46#issuecomment-29804693).
