### PR TITLE
Use ensure_packages to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Requires the following boxen modules:
 
 * `boxen`
 * `homebrew`
+* `stdlib`
 * `wget`
 * `autoconf`
 * `libtool`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class php {
   require php::config
   require homebrew
   include wget
+  include stdlib
   include autoconf
   include libtool
   include pkgconfig
@@ -60,16 +61,7 @@ class php {
   }
 
   # Resolve dependencies
-
-  package { [
-      'gmp',
-      'icu4c',
-      'jpeg',
-      'libevent',
-      'mcrypt',
-    ]:
-    provider => homebrew,
-  }
+  ensure_packages( [ 'libevent', 'gmp', 'icu4c', 'jpeg', 'mcrypt', ] )
 
   # Install freetype version 2.4.11 due to conflict with GD
   # See https://github.com/boxen/puppet-php/issues/25

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -7,6 +7,7 @@ describe "php" do
   it do
     should include_class("php::config")
     should include_class("homebrew")
+    should include_class("stdlib")
     should include_class("wget")
     should include_class("autoconf")
     should include_class("libtool")
@@ -63,7 +64,7 @@ describe "php" do
       "libevent",
       "mcrypt"
     ].each do |pkg|
-      should contain_package(pkg).with_provider("homebrew")
+      should contain_package(pkg)
     end
 
     should contain_homebrew__formula("autoconf213").with({


### PR DESCRIPTION
Without using ensure_packages, anybody using other modules with the same requirements will have to jump through lots of annoying hoops to get their dependencies installed while avoiding duplicate package declaration errors from puppet.
