### PR TITLE
Set PECL to be the default extension provider

### DIFF
--- a/lib/puppet/provider/php_extension/pecl.rb
+++ b/lib/puppet/provider/php_extension/pecl.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:php_extension).provide(:pecl) do
   include Puppet::Util::Execution
   desc "Provides PHP extensions compiled from their pecl source code"
 
-  defaultfor :source => :pecl
+  defaultfor :operatingsystem => :darwin
 
   # Build and install our PHP extension
   def create

--- a/lib/puppet/type/php_extension.rb
+++ b/lib/puppet/type/php_extension.rb
@@ -51,10 +51,6 @@ Puppet::Type.newtype(:php_extension) do
     defaultto ''
   end
 
-  newparam(:source) do
-    defaultto :pecl
-  end
-
   # Some PECL modules have a different module layout and the php extension
   # source in not in the root directory (e.g. xhprof)
   newparam(:extension_dir) do


### PR DESCRIPTION
Removes some cruft I added a long time ago with the `:source` param, and just sets the default provider on Mac OS to be the `:pecl` provider.

Hopefully fixes #44 - I've tested on Mavericks with Puppet **3.6.1** and the multiple default provider warnings are resolved.
