### PR TITLE
[BUGFIX] pm.max_children too small for some (XHR-heavy) projects

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -203,9 +203,10 @@ define php::project(
 
     # Spin up a PHP-FPM pool for this project, listening on an Nginx socket
     php::fpm::pool { "${name}-${php}":
-      version     => $php,
-      socket_path => "${boxen::config::socketdir}/${name}",
-      require     => File["${nginx::config::sitesdir}/${name}.conf"],
+      version      => $php,
+      socket_path  => "${boxen::config::socketdir}/${name}",
+      require      => File["${nginx::config::sitesdir}/${name}.conf"],
+      max_children => 10,
     }
 
     if $fpm_pool {


### PR DESCRIPTION
The default of 2 is a bit too small for most of our projects here, which sometimes require a few quick simultaneous connections per URL.  It looks like this update might be useful for others, too (e.g. boxen/puppet-php#46).  I don't think having a default of 10 will hurt anything, but am open to other suggestions/approaches (e.g. exposing the max_children setting at a higher level?)...
