### PR TITLE
Remove autoconf213 sandboxing which breaks new installs

### DIFF
--- a/files/brews/autoconf213.rb
+++ b/files/brews/autoconf213.rb
@@ -6,8 +6,6 @@ class Autoconf213 < Formula
   mirror 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz'
   sha1 'e4826c8bd85325067818f19b2b2ad2b625da66fc'
 
-  keg_only "Sandboxed for PHP installations"
-
   version '2.13-boxen1'
 
   def install


### PR DESCRIPTION
Sandboxing the autoconf package as _keg_only_ means that the `autoconf213` and `autoheader213` binaries aren't symlinked into the Homebrew `bin` folder. This then means the php version provider can't find these for the older versions of PHP and installs fail.
