### PR TITLE
Set cachedir for imagick

### DIFF
--- a/manifests/extension/imagick.pp
+++ b/manifests/extension/imagick.pp
@@ -37,6 +37,7 @@ define php::extension::imagick(
     phpenv_root      => $php::config::root,
     php_version      => $php,
     configure_params => $configure_params,
+    cache_dir        => $php::config::extensioncachedir,
   }
 
   # Add config file once extension is installed


### PR DESCRIPTION
Imagick files now downloads to `/` which isn't very nice. :)

https://github.com/oddhill/oddboxen/issues/575

:swimmer: 