### PR TITLE
Fix the usage of libssh2 in ssh2 extension

### DIFF
--- a/manifests/extension/ssh2.pp
+++ b/manifests/extension/ssh2.pp
@@ -11,12 +11,12 @@ define php::extension::ssh2(
   $php,
   $version = '0.12'
 ) {
-  require ssh2::lib
-
   require php::config
   # Require php version eg. php::5_4_10
   # This will compile, install and set up config dirs if not present
   php_require($php)
+
+  package { 'libssh2': }
 
   $extension = 'ssh2'
   $package_name = "ssh2-${version}"
@@ -26,7 +26,7 @@ define php::extension::ssh2(
   $module_path = "${php::config::root}/versions/${php}/modules/${extension}.so"
 
   # Additional options
-  $configure_params = "--with-libssh2=${boxen::config::homebrewdir}/opt/libssh2"
+  $configure_params = "--with-ssh2=${boxen::config::homebrewdir}/opt/libssh2"
 
   php_extension { $name:
     extension        => $extension,
@@ -39,6 +39,7 @@ define php::extension::ssh2(
     cache_dir        => $php::config::extensioncachedir,
     provider         => pecl,
     configure_params => $configure_params,
+    require          => Package['libssh2'],
   }
 
   # Add config file once extension is installed

--- a/spec/defines/extensions/php_extension_ssh2_spec.rb
+++ b/spec/defines/extensions/php_extension_ssh2_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe "php::extension::ssh2" do
-  let(:pre_condition) { "class ssh2::lib {}" }
   let(:facts) { default_test_facts }
   let(:title) { "ssh2 for 5.4.17" }
   let(:params) do
@@ -13,7 +12,6 @@ describe "php::extension::ssh2" do
 
   it do
     should contain_class("boxen::config")
-    should contain_class("ssh2::lib")
     should contain_class("php::config")
     should contain_php__version("5.4.17")
 
@@ -27,6 +25,7 @@ describe "php::extension::ssh2" do
       :php_version      => "5.4.17",
       :cache_dir        => "/test/boxen/data/php/cache/extensions",
       :provider         => "pecl",
+      :require          => "Package[libssh2]"
     })
 
     should contain_file("/test/boxen/config/php/5.4.17/conf.d/ssh2.ini").with({


### PR DESCRIPTION
The way libssh2 is required, requires some puppet code that is not specified anywhere. This fix specifies the homebrew package as requirement of the extension and fixes the command line argument.

Fixes #79 