### PR TITLE
Update brews to use sha256

### DIFF
--- a/files/brews/autoconf213.rb
+++ b/files/brews/autoconf213.rb
@@ -4,7 +4,7 @@ class Autoconf213 < Formula
   homepage 'http://www.gnu.org/software/autoconf/'
   url 'http://ftpmirror.gnu.org/autoconf/autoconf-2.13.tar.gz'
   mirror 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz'
-  sha1 'e4826c8bd85325067818f19b2b2ad2b625da66fc'
+  sha256 'f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e'
 
   version '2.13-boxen1'
 

--- a/files/brews/bison26.rb
+++ b/files/brews/bison26.rb
@@ -4,7 +4,7 @@ class Bisonphp26 < Formula
   homepage 'http://www.gnu.org/software/bison/'
   url 'http://ftpmirror.gnu.org/bison/bison-2.6.4.tar.gz'
   mirror 'http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz'
-  sha1 '38adec0d7d0f556ec52e21ccbb87edd78327dd9b'
+  sha256 'de2d15dfdcfc24405464cb95acc9d5ef31fb2e5be4aca6a530ec59bb57c30e5d'
 
   version '2.6.4-boxen1'
 

--- a/files/brews/freetds.rb
+++ b/files/brews/freetds.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Freetds < Formula
   homepage 'http://www.freetds.org/'
   url 'http://mirrors.ibiblio.org/freetds/stable/freetds-0.91.tar.gz'
-  sha1 '3ab06c8e208e82197dc25d09ae353d9f3be7db52'
+  sha256 '6a8148bd803aebceac6862b0dead1c5d9659f7e1038993abfe0ce8febb322465'
 
   depends_on "pkg-config" => :build
   depends_on "unixodbc" => :optional

--- a/files/brews/freetype.rb
+++ b/files/brews/freetype.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Freetypephp < Formula
   homepage 'http://www.freetype.org'
   url 'http://downloads.sf.net/project/freetype/freetype2/2.4.11/freetype-2.4.11.tar.gz'
-  sha1 'a8373512281f74a53713904050e0d71c026bf5cf'
+  sha256 '29a70e55863e4b697f6d9f3ddc405a88b83a317e3c8fd9c09dc4e4c8b5f9ec3e'
 
   keg_only "Sandboxed for PHP installations"
 
@@ -11,7 +11,7 @@ class Freetypephp < Formula
 
   bottle do
     # Included with X11 so no bottle needed before Mountain Lion.
-    sha1 '7dc4747810e51beb99fd36c8f5baade6e65d19b7' => :mountain_lion
+    sha256 'TODO_Figure_this_out' => :mountain_lion
   end
 
   def install

--- a/files/brews/zlib.rb
+++ b/files/brews/zlib.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Zlibphp < Formula
   homepage 'http://www.zlib.net/'
   url 'http://zlib.net/zlib-1.2.8.tar.gz'
-  sha1 'a4d316c404ff54ca545ea71a27af7dbc29817088'
+  sha256 '36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d'
 
   keg_only :provided_by_osx
 


### PR DESCRIPTION
```
Error: Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
```

The following changes should allow this module to install again, previously `sha1` was merely deprecated and produced a warning but with this amendment we should be able to bypass the error.

Methodology:
1. wget the path in the `url`
2. `shasum -a1 zlib-1.2.8.tar.gz` and compare the output with the sha currently defined so that they match, and that we can confirm the new sha is valid. 
2. `shasum -a256 zlib-1.2.8.tar.gz`
3. update the file to use 256 with the newly defined sha 

Note the TODO in freetype, I am not sure what this piece of code is doing, it doesn't trigger on my el capitan machine. Simply changing this to sha256 stops my code outright dying, but doesn't seem to trigger anything. Any pointers?